### PR TITLE
Expose AbortSignal to handlers for cooperative cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,25 @@ const consumer = new SQSConsumer({
 
 ```
 
+## Handler cancellation on timeout
+
+When `handlerOptions.executionTimeout` triggers, the consumer aborts the in-flight handler via an `AbortSignal` exposed through `AsyncLocalStorage`. The handler does not need to receive the signal as an argument — it is retrieved on demand using the `getAbortSignal` helper. Pass it to any cancellable async API (`fetch`, `undici`, timers, streams) to release resources promptly and avoid zombie handlers retaining memory after a timeout.
+
+```typescript
+import { SQSConsumer, getAbortSignal } from '@fgiova/sqs-consumer'
+
+const consumer = new SQSConsumer({
+    queueARN: "arn:aws:sqs:eu-central-1:000000000000:test-queue-hooks",
+    handler: async (message) => {
+        const signal = getAbortSignal();
+        const res = await fetch("https://api.example.com/work", { signal });
+        return res.json();
+    }
+});
+```
+
+`getAbortSignal()` returns `undefined` when called outside a handler execution context. Handlers that ignore it keep working unchanged.
+
 ## Options
 | Option          | Type                                | Default | Description                                        |
 |-----------------|-------------------------------------|---------|----------------------------------------------------|
@@ -86,6 +105,7 @@ SQSConsumer(options: SQSConsumerOptions)
 SQSConsumer.start(): Promise<void>
 SQSConsumer.stop(destroyConsumer = false): Promise<void>
 SQSConsumer.addHook<H extends HookName>(hookName: H, value: HookCallback<H>): this
+getAbortSignal(): AbortSignal | undefined
 ```
 
 ## License

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
 	"name": "@fgiova/sqs-consumer",
-	"version": "2.2.1",
+	"version": "3.0.0",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@fgiova/sqs-consumer",
-			"version": "2.2.1",
+			"version": "3.0.0",
 			"license": "MIT",
 			"dependencies": {
-				"@fgiova/mini-sqs-client": "^4.0.0",
+				"@fgiova/mini-sqs-client": "^5.0.0",
 				"@watchable/unpromise": "^1.0.2",
 				"p-map": "^7.0.3"
 			},
@@ -977,9 +977,9 @@
 			}
 		},
 		"node_modules/@fgiova/aws-signature": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@fgiova/aws-signature/-/aws-signature-4.0.0.tgz",
-			"integrity": "sha512-PNWIBR7CRnB83VV699XRaW3q+YuAYCJEO4Z0Zv33W/RqI1B4es2WHlevI89l3ALBXQKdeEQ1Il/hhJZ8vXngIg==",
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/@fgiova/aws-signature/-/aws-signature-4.2.0.tgz",
+			"integrity": "sha512-VQF2w6bkmbAaAmUlTwZSsEeTs/wmsz3eo9sRJw5jmBd27VnqXzCw/rSQUN/6cB0CZ05Ixh7D91k0ODrYs2AzzQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@sinclair/typebox": "^0.34.48",
@@ -1020,13 +1020,13 @@
 			"dev": true
 		},
 		"node_modules/@fgiova/mini-sqs-client": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/@fgiova/mini-sqs-client/-/mini-sqs-client-4.0.0.tgz",
-			"integrity": "sha512-8HKvN+8iJv14i0t0Sr74LI7OMpgluwP14ZCFoKBmbvY+6qworkgYl+LjF7hELFmOgAWxWrYstauoNIhKLgg0/w==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/@fgiova/mini-sqs-client/-/mini-sqs-client-5.0.0.tgz",
+			"integrity": "sha512-bV4euMK6pjXhtyVUqvxwVohzBu8gXBf2UienOEjwxH+yIcm2IUDq2pDtDCpIyaQ5UCgieaeQxedPpz3enPPZfA==",
 			"license": "MIT",
 			"dependencies": {
-				"@fgiova/aws-signature": "^4.0.0",
-				"undici": "^7.21.0"
+				"@fgiova/aws-signature": "^4.2.0",
+				"undici": "^7.25.0"
 			},
 			"engines": {
 				"node": "^22.14.0 || >= 24.10.0"
@@ -1901,7 +1901,6 @@
 			"integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@octokit/auth-token": "^6.0.0",
 				"@octokit/graphql": "^9.0.3",
@@ -3497,7 +3496,6 @@
 			"resolved": "https://registry.npmjs.org/@tapjs/core/-/core-4.0.1.tgz",
 			"integrity": "sha512-gJq1Y/4kqnb7+FDl1RbaiEQ1/g9MrnUUwGnqGo2CNJturb+q9AhgYKjlEXFCnsdy1nXQgqeKSToEPU66LepZJw==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"@tapjs/processinfo": "^3.1.8",
 				"@tapjs/stack": "4.0.0",
@@ -4270,7 +4268,6 @@
 			"integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
@@ -7750,7 +7747,6 @@
 			"integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"bin": {
 				"marked": "bin/marked.js"
 			},
@@ -10349,7 +10345,6 @@
 			"dev": true,
 			"inBundle": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -11125,7 +11120,6 @@
 			"resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
 			"integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
 			"dev": true,
-			"peer": true,
 			"dependencies": {
 				"loose-envify": "^1.1.0"
 			},
@@ -11495,7 +11489,6 @@
 			"integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@semantic-release/commit-analyzer": "^13.0.1",
 				"@semantic-release/error": "^4.0.0",
@@ -12964,7 +12957,6 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
-			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -13236,7 +13228,6 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
 			"integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -13259,9 +13250,9 @@
 			}
 		},
 		"node_modules/undici": {
-			"version": "7.21.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-7.21.0.tgz",
-			"integrity": "sha512-Hn2tCQpoDt1wv23a68Ctc8Cr/BHpUSfaPYrkajTXOS9IKpxVRx/X5m1K2YkbK2ipgZgxXSgsUinl3x+2YdSSfg==",
+			"version": "7.25.0",
+			"resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+			"integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=20.18.1"
@@ -13679,7 +13670,6 @@
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.7.0.tgz",
 			"integrity": "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==",
 			"dev": true,
-			"peer": true,
 			"bin": {
 				"yaml": "bin.mjs"
 			},

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
 		]
 	},
 	"dependencies": {
-		"@fgiova/mini-sqs-client": "^4.0.0",
+		"@fgiova/mini-sqs-client": "^5.0.0",
 		"@watchable/unpromise": "^1.0.2",
 		"p-map": "^7.0.3"
 	},

--- a/src/context.ts
+++ b/src/context.ts
@@ -1,0 +1,11 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+type HandlerContext = {
+	signal: AbortSignal;
+};
+
+export const handlerContext = new AsyncLocalStorage<HandlerContext>();
+
+export function getAbortSignal(): AbortSignal | undefined {
+	return handlerContext.getStore()?.signal;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,10 +145,15 @@ export class SQSConsumer {
 		try {
 			let handlerResult: unknown;
 			if (this.handlerOptions.executionTimeout) {
+				const handlerPromise = handlerContext.run(
+					{ signal: abortController.signal },
+					() => handler(message),
+				);
+				// Swallow late rejection of the loser when timeout wins the race,
+				// otherwise it surfaces as an unhandledRejection.
+				handlerPromise.catch(() => {});
 				handlerResult = await Unpromise.race([
-					handlerContext.run({ signal: abortController.signal }, () =>
-						handler(message),
-					),
+					handlerPromise,
 					new Promise((_resolve, reject) => {
 						timeoutId = setTimeout(() => {
 							const err = new TimeoutError("Handler execution timed out");

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,12 @@ import { Unpromise } from "@watchable/unpromise";
 // @ts-expect-error
 import pMap from "p-map";
 import type { Pool } from "undici";
+import { handlerContext } from "./context";
 import { TimeoutError } from "./errors";
 import { type HookCallback, type HookName, Hooks } from "./hooks";
 import type { Logger } from "./logger";
+
+export { getAbortSignal } from "./context";
 
 type HandlerOptions = {
 	deleteMessage?: boolean;
@@ -138,19 +141,27 @@ export class SQSConsumer {
 		message: Message,
 	) {
 		let timeoutId: ReturnType<typeof setTimeout> | null = null;
+		const abortController = new AbortController();
 		try {
 			let handlerResult: unknown;
 			if (this.handlerOptions.executionTimeout) {
 				handlerResult = await Unpromise.race([
-					handler(message),
+					handlerContext.run({ signal: abortController.signal }, () =>
+						handler(message),
+					),
 					new Promise((_resolve, reject) => {
 						timeoutId = setTimeout(() => {
-							reject(new TimeoutError("Handler execution timed out"));
+							const err = new TimeoutError("Handler execution timed out");
+							abortController.abort(err);
+							reject(err);
 						}, this.handlerOptions.executionTimeout);
 					}),
 				]);
 			} else {
-				handlerResult = await handler(message);
+				handlerResult = await handlerContext.run(
+					{ signal: abortController.signal },
+					() => handler(message),
+				);
 			}
 			await this.hooks.runHook("onHandlerSuccess", message);
 			return handlerResult;

--- a/test/helpers/localtest.ts
+++ b/test/helpers/localtest.ts
@@ -1,11 +1,13 @@
 import fs from "node:fs";
 import { Socket } from "node:net";
 import path from "node:path";
+import dotEnv from "dotenv";
 import { teardown } from "tap";
 
 const defaultExport = () => {
-	require("dotenv").config({
+	dotEnv.config({
 		path: ".env.dev",
+		quiet: true,
 	});
 	if (!process.env.TEST_LOCAL) {
 		const jsonString = fs.readFileSync(

--- a/test/scripts/executors/before.js
+++ b/test/scripts/executors/before.js
@@ -26,6 +26,7 @@ const before = async () => {
 	if (!process.env.TEST_LOCAL) {
 		console.log("Start Reaper");
 		const reaperEnv = await startReaper();
+		process.env.REAPER_SESSION_ID = reaperEnv.REAPER_SESSION;
 		console.log("Start LocalStack");
 		const {
 			// biome-ignore lint/correctness/noUnusedVariables: leave for clarity

--- a/test/scripts/runners/localstack.js
+++ b/test/scripts/runners/localstack.js
@@ -49,6 +49,9 @@ const bootstrap = async (host, port) => {
 	await sqs.createQueue({
 		QueueName: "test-queue-hooks",
 	});
+	await sqs.createQueue({
+		QueueName: "test-queue-context",
+	});
 };
 
 module.exports = {

--- a/test/scripts/runners/localstack.js
+++ b/test/scripts/runners/localstack.js
@@ -2,7 +2,7 @@ const { SQS } = require("@aws-sdk/client-sqs");
 const { GenericContainer, Wait } = require("testcontainers");
 
 const startLocalStack = async () => {
-	const localStack = await new GenericContainer("localstack/localstack:latest")
+	const localStack = await new GenericContainer("localstack/localstack:4")
 		.withLabels({
 			"org.testcontainers.reaper-session-id": process.env.REAPER_SESSION_ID, // This is mandatory for the reaper to clean up the container
 		})
@@ -10,17 +10,10 @@ const startLocalStack = async () => {
 		.withEnvironment({
 			SERVICES: "sqs,sns",
 			DEBUG: "1",
-			DOCKER_HOST: "unix:///var/run/docker.sock",
 			NODE_TLS_REJECT_UNAUTHORIZED: "0",
 			HOSTNAME: "localhost",
 			AWS_DEFAULT_REGION: "eu-central-1",
 		})
-		.withBindMounts([
-			{
-				source: "/var/run/docker.sock",
-				target: "/var/run/docker.sock",
-			},
-		])
 		.withWaitStrategy(Wait.forListeningPorts())
 		.start();
 	const port = localStack.getMappedPort(4566);

--- a/test/test/context.ts
+++ b/test/test/context.ts
@@ -1,0 +1,111 @@
+// biome-ignore lint/suspicious/noTsIgnore: is a Test file
+// @ts-ignore
+import "../helpers/localtest";
+import { setTimeout } from "node:timers/promises";
+import { Signer } from "@fgiova/aws-signature";
+import { type Message, MiniSQSClient } from "@fgiova/mini-sqs-client";
+import { before, teardown, test } from "tap";
+import { getAbortSignal, SQSConsumer } from "../../src/index";
+// biome-ignore lint/suspicious/noTsIgnore: is a Test file
+// @ts-ignore
+import { sqsPurge } from "../helpers/sqsMessage";
+
+const queueARN = "arn:aws:sqs:eu-central-1:000000000000:test-queue-context";
+let signer: Signer;
+let client: MiniSQSClient;
+before(() => {
+	signer = new Signer();
+	client = new MiniSQSClient(
+		"eu-central-1",
+		process.env.LOCALSTACK_ENDPOINT,
+		undefined,
+		signer,
+	);
+});
+teardown(async () => {
+	await signer.destroy();
+});
+
+test("getAbortSignal", { only: true }, async (t) => {
+	await t.test("returns undefined outside handler context", async (t) => {
+		t.equal(getAbortSignal(), undefined);
+	});
+
+	await t.test("returns AbortSignal inside handler context", async (t) => {
+		const messageToSend = {
+			MessageBody: "Hello World!",
+		};
+		await client.sendMessage(queueARN, messageToSend);
+
+		const signalState = new Promise<{
+			isSignal: boolean;
+			aborted: boolean;
+		}>((resolve) => {
+			const consumer = new SQSConsumer({
+				queueARN,
+				handler: async (_message: Message) => {
+					const signal = getAbortSignal();
+					resolve({
+						isSignal: signal instanceof AbortSignal,
+						aborted: signal?.aborted ?? true,
+					});
+					return { success: true };
+				},
+				clientOptions: {
+					endpoint: process.env.LOCALSTACK_ENDPOINT,
+					signer,
+				},
+				consumerOptions: {
+					waitTimeSeconds: 1,
+				},
+			});
+			t.teardown(async () => {
+				await consumer.stop();
+				await sqsPurge(queueARN);
+			});
+		});
+
+		const state = await signalState;
+		t.equal(state.isSignal, true);
+		t.equal(state.aborted, false);
+	});
+
+	await t.test("signal aborts on handler timeout", async (t) => {
+		const messageToSend = {
+			MessageBody: "Hello World!",
+		};
+		await client.sendMessage(queueARN, messageToSend);
+
+		const abortReason = new Promise<unknown>((resolve) => {
+			const consumer = new SQSConsumer({
+				queueARN,
+				handler: async (message: Message) => {
+					const signal = getAbortSignal();
+					await setTimeout(3_000);
+					// biome-ignore lint/style/noNonNullAssertion: ReceiptHandle must be present here
+					await client.deleteMessage(queueARN, message.ReceiptHandle!);
+					resolve(signal?.reason);
+					return { success: true };
+				},
+				handlerOptions: {
+					executionTimeout: 500,
+				},
+				clientOptions: {
+					endpoint: process.env.LOCALSTACK_ENDPOINT,
+					signer,
+				},
+				consumerOptions: {
+					waitTimeSeconds: 1,
+				},
+			});
+			t.teardown(async () => {
+				await consumer.stop();
+				await sqsPurge(queueARN);
+			});
+		});
+
+		const reason = await abortReason;
+		t.ok(reason instanceof Error);
+		t.equal((reason as Error).name, "TimeoutError");
+	});
+});

--- a/test/test/error.ts
+++ b/test/test/error.ts
@@ -260,6 +260,63 @@ test("sqs-consumer class Errors", { only: true }, async (t) => {
 		await consumer.stop(true);
 		await t.rejects(consumer.start(), "Consumer is destroyed");
 	});
+	await t.test(
+		"No unhandled rejection when handler throws after timeout",
+		async (t) => {
+			const messageToSend = {
+				MessageBody: "Hello World!",
+			};
+			await client.sendMessage(queueARN, messageToSend);
+
+			const unhandled: unknown[] = [];
+			const onUnhandled = (reason: unknown) => {
+				unhandled.push(reason);
+			};
+			process.on("unhandledRejection", onUnhandled);
+
+			const consumer = new SQSConsumer({
+				queueARN,
+				handler: async () => {
+					await setTimeout(800);
+					throw new Error("late-throw-after-timeout");
+				},
+				handlerOptions: {
+					executionTimeout: 200,
+				},
+				clientOptions: {
+					endpoint: process.env.LOCALSTACK_ENDPOINT,
+					signer,
+				},
+				consumerOptions: {
+					waitTimeSeconds: 1,
+				},
+			});
+			const timeoutSeen = new Promise<Message>((resolve) => {
+				consumer.addHook("onHandlerTimeout", async (message: Message) => {
+					// biome-ignore lint/style/noNonNullAssertion: ReceiptHandle must be present here
+					await client.deleteMessage(queueARN, message.ReceiptHandle!);
+					resolve(message);
+					return true;
+				});
+			});
+
+			t.teardown(async () => {
+				await consumer.stop();
+				process.removeListener("unhandledRejection", onUnhandled);
+			});
+
+			await timeoutSeen;
+			// Wait past the handler's late-throw moment (handler sleeps 800ms,
+			// timeout fires at 200ms — give the late throw time to surface).
+			await setTimeout(1500);
+			t.equal(
+				unhandled.length,
+				0,
+				"late handler rejection must not surface as unhandledRejection",
+			);
+		},
+	);
+
 	await t.test("Not stop a not running consumer", async (t) => {
 		const consumer = new SQSConsumer({
 			queueARN,


### PR DESCRIPTION
This pull request introduces handler cancellation support via `AbortSignal` for the SQS consumer, allowing handlers to be aborted when they exceed their execution timeout. It also updates the documentation and adds comprehensive tests to ensure correct behavior and prevent unhandled promise rejections after timeouts. Additionally, it updates a dependency to the latest major version.

### Handler cancellation and context propagation

* Introduced `AsyncLocalStorage`-based context (`handlerContext`) to inject an `AbortSignal` into the handler execution context, accessible via the new `getAbortSignal()` helper. This enables handler cancellation on timeout, allowing integration with cancellable APIs like `fetch` or `undici`. (`src/context.ts` [[1]](diffhunk://#diff-0cd594dddd6a9f2e3e26afebbb92716434437d7001c2416252aa7531e7f2b8d4R1-R11) `src/index.ts` [[2]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R9-R15) [[3]](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R144-R169)
* When `handlerOptions.executionTimeout` is set, the handler is run with an associated `AbortController` signal. If the timeout triggers, the signal is aborted and the handler is promptly cancelled. (`src/index.ts` [src/index.tsR144-R169](diffhunk://#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R144-R169))

### Documentation updates

* Updated `README.md` to document the new handler cancellation feature, including usage instructions for `getAbortSignal()`, and added it to the API reference. (`README.md` [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R32-R50) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R108)

### Testing improvements

* Added a new test suite for handler context and cancellation, verifying that `getAbortSignal()` behaves as expected inside and outside handler contexts and that the signal aborts on timeout. (`test/test/context.ts` [[1]](diffhunk://#diff-aeca9db6b876166210fe3c9bb79718d8fa0a8da8bbda44ec3b3a3eae0c521ec0R1-R111) `test/scripts/runners/localstack.js` [[2]](diffhunk://#diff-4ccc4d81b25989d10d6bb9bf67eb8ae041f77e3196ddda5b47b151383595fe9dR52-R54)
* Extended error handling tests to ensure that late handler rejections after a timeout do not result in unhandled promise rejections. (`test/test/error.ts` [test/test/error.tsR263-R319](diffhunk://#diff-e1e25625cde591a69715853275c90e749d9408aee836fda0116bf0676d706637R263-R319))

### Dependency updates

* Bumped `@fgiova/mini-sqs-client` dependency from v4 to v5 for compatibility and improvements. (`package.json` [package.jsonL59-R59](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L59-R59))

### Test setup improvements

* Updated test helpers to use the `dotenv` package directly for loading environment variables. (`test/helpers/localtest.ts` [test/helpers/localtest.tsR4-R10](diffhunk://#diff-412a68f76eb3d9eb7c65a6686578fa40e1bbf255f9ee14ebc584df0c547fda0cR4-R10))